### PR TITLE
Adding HTTPS support

### DIFF
--- a/lib/crunchbase-api/configuration.rb
+++ b/lib/crunchbase-api/configuration.rb
@@ -3,7 +3,7 @@ module Crunchbase
 
     OPTIONS = [:user_key, :api_endpoint].freeze
     USER_KEY = nil
-    API_ENDPOINT = 'http://api.crunchbase.com/v/2'
+    API_ENDPOINT = 'https://api.crunchbase.com/v/2'
 
     attr_accessor *OPTIONS
 


### PR DESCRIPTION
Crunchbase requires the use of HTTPS for their API now. HTTP requests just don't work anymore.
I've made the necessary change, please review.